### PR TITLE
chore: add k8s-do Terraform module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# infra
-AsyncAPI Infrastructure as code
+<h5 align="center">
+  <br />
+  <a href="https://www.asyncapi.org"
+    ><img
+      src="https://github.com/asyncapi/parser-nodejs/raw/master/assets/logo.png"
+      alt="AsyncAPI logo"
+      width="200"
+  /></a>
+</h5>
+<p align="center">
+  <em>
+    Infrastructure as code for hosting AsyncAPI projects.<br />You will mainly find
+    Terraform modules, and other configuration files here
+  </em>
+</p>

--- a/k8s-do/.terraform.lock.hcl
+++ b/k8s-do/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/digitalocean/digitalocean" {
+  version     = "2.14.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:mweBY6X5RubSqiJwqj8m1gURO4NB1Wgfaihy1TwWqpY=",
+    "zh:0714ad222e337fb8554b7895172c97b88d8a1dbfa9627c3dda1e01406c7e166d",
+    "zh:2392648a6cba18f80e3c2ba6549669f7efbbd7cd32fdb1995f261c511910d6c6",
+    "zh:24db17ca7bada30aec0d0241fc621a26faa72e721f0ec0139bbe78c88ca65d5d",
+    "zh:256ea261adcf6a3015faa200be8d50b32fd53e5302139c4c711c418f4ccf2e3e",
+    "zh:2ba040e073a3df44c1366171bff44a8bec4e4ccbd4f37856660c994e39a637b5",
+    "zh:3049f5c307c499865a3601c99334002632301ffc13e2a232d77a3abb5377df65",
+    "zh:4a63489600f44e16878af90c1702f7b71fa5d610b707f59cc1deb72f4a999d94",
+    "zh:9dac8c2d3dc060664adb7144cb1cb61009460a334d9a2ac0499ce273aa9415ff",
+    "zh:a5baa344ecd58c938c21b3af0ef56845ce131eb2370da591b14ef69c07876c23",
+    "zh:b63983705e64014cd2f024100976632e6c97c48cf0c11bb2fbebe1ce39d3d4cb",
+    "zh:bd479c40560c8b008db420bf2847e53fcd265f8def54d1220b360f9842c79059",
+    "zh:c39a45442d443f7d2e7833d96d35d6744576d24ea72604124df1507646499644",
+    "zh:ebc8dd3807f686d647af6dde901ecf8b57abb8b06bfe44cb9e2f6efb16124cb9",
+    "zh:ec8887f1095d639301121c0cb4b79e83e78d4140a250a4a426904460773fb43b",
+    "zh:ecb109681f1f9599661cdef7265fbe3a215a56f38f50e331a6487c343cdc3a57",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/template" {
+  version = "2.2.0"
+  hashes = [
+    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
+    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+  ]
+}

--- a/k8s-do/CODEOWNERS
+++ b/k8s-do/CODEOWNERS
@@ -1,0 +1,8 @@
+# This file provides an overview of code owners in this repository.
+
+# Each line is a file pattern followed by one or more owners.
+# The last matching pattern has the most precedence.
+# For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
+
+# The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
+* @smoya @github-actions[bot]

--- a/k8s-do/README.md
+++ b/k8s-do/README.md
@@ -1,0 +1,40 @@
+# AsyncAPI Kubernetes cluster on Digital Ocean
+
+Digital Ocean provides a managed Kubernetes cluster on their cloud.
+This Terraform module allows you to create such a cluster by using the official [Digital Ocean Terraform Provider](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/kubernetes_cluster).
+
+## Prerequisites
+
+* Install [Terraform](https://www.terraform.io/).
+* Generate a [Digital Ocean API token](https://cloud.digitalocean.com/account/api/).
+
+## Run
+
+If this is your first time, you will need to run the following command:
+
+```bash
+terraform init
+```
+
+Then you can run the following command to apply changes:
+
+```bash
+DIGITALOCEAN_TOKEN=<your-token> terraform apply
+```
+
+## Customize cluster properties
+
+The cluster properties can be customized by setting any of the variables available at `variables.tf`.
+All you need to do is create your own variables file `main.tfvars` and set the variables you want to customize. I.e.:
+
+```terraform
+region = "sfo2"
+cluster_name = "my-awesome-cluster"
+cluster_node_count_min = 5
+```
+
+Then, apply the changes:
+
+```bash
+DIGITALOCEAN_TOKEN=<your-token> terraform apply -var-file=main.tfvars
+```

--- a/k8s-do/main.tf
+++ b/k8s-do/main.tf
@@ -13,14 +13,14 @@ provider "digitalocean" {
 }
 
 resource "digitalocean_kubernetes_cluster" "asyncapi-k8s-cluster" {
-  name   = var.cluster_name
-  region = var.region
+  name    = var.cluster_name
+  region  = var.region
   version = var.cluster_version
 
   node_pool {
     name       = var.cluster_node_pool_name
     size       = var.cluster_node_size
-    auto_scale = true
+    auto_scale = var.cluster_node_auto_scale
     min_nodes  = var.cluster_node_count_min
     max_nodes  = var.cluster_node_count_max
   }

--- a/k8s-do/main.tf
+++ b/k8s-do/main.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
+  }
+}
+
+# Configure the DigitalOcean Provider
+provider "digitalocean" {
+  token = var.do_token
+}
+
+resource "digitalocean_kubernetes_cluster" "asyncapi-k8s-cluster" {
+  name   = var.cluster_name
+  region = var.region
+  version = var.cluster_version
+
+  node_pool {
+    name       = var.cluster_node_pool_name
+    size       = var.cluster_node_size
+    auto_scale = true
+    min_nodes  = var.cluster_node_count_min
+    max_nodes  = var.cluster_node_count_max
+  }
+}

--- a/k8s-do/variables.tf
+++ b/k8s-do/variables.tf
@@ -3,36 +3,41 @@
 variable "do_token" {}
 
 variable "region" {
-  type = string
+  type    = string
   default = "nyc1" # Regions list: `doctl kubernetes options regions`
 }
 
 variable "cluster_name" {
-  type = string
+  type    = string
   default = "asyncapi-demo"
 }
 
 variable "cluster_version" {
-  type = string
+  type    = string
   default = "1.21.5-do.0" # Versions list: `doctl kubernetes options versions`
 }
 
 variable "cluster_node_pool_name" {
-  type = string
+  type    = string
   default = "asyncapi-demo-pool"
 }
 
 variable "cluster_node_size" {
-  type = string
+  type    = string
   default = "s-2vcpu-4gb" # Sizes list: `doctl kubernetes options sizes`
 }
 
+variable "cluster_node_auto_scale" {
+  type    = bool
+  default = false
+}
+
 variable "cluster_node_count_min" {
-  type = number
+  type    = number
   default = 3
 }
 
 variable "cluster_node_count_max" {
-  type = number
+  type    = number
   default = 5
 }

--- a/k8s-do/variables.tf
+++ b/k8s-do/variables.tf
@@ -1,0 +1,38 @@
+# Set the variable value in *.tfvars file
+# or using -var="do_token=..." CLI option
+variable "do_token" {}
+
+variable "region" {
+  type = string
+  default = "nyc1" # Regions list: `doctl kubernetes options regions`
+}
+
+variable "cluster_name" {
+  type = string
+  default = "asyncapi-demo"
+}
+
+variable "cluster_version" {
+  type = string
+  default = "1.21.5-do.0" # Versions list: `doctl kubernetes options versions`
+}
+
+variable "cluster_node_pool_name" {
+  type = string
+  default = "asyncapi-demo-pool"
+}
+
+variable "cluster_node_size" {
+  type = string
+  default = "s-2vcpu-4gb" # Sizes list: `doctl kubernetes options sizes`
+}
+
+variable "cluster_node_count_min" {
+  type = number
+  default = 3
+}
+
+variable "cluster_node_count_max" {
+  type = number
+  default = 5
+}


### PR DESCRIPTION
**Description**

This PR adds a Terraform module that creates a managed K8s cluster in Digital Ocean so we can host our services there.

This Terraform module was created as part of the event-gateway-demo work, so I'm moving it from https://github.com/asyncapi/event-gateway/tree/master/deployments/asyncapi-k8s-demo-cluster to this repo.