### PR TITLE
feat: add ingress-tls helm chart

### DIFF
--- a/k8s-do/k8s/.gitignore
+++ b/k8s-do/k8s/.gitignore
@@ -1,0 +1,1 @@
+**/charts/*.tgz

--- a/k8s-do/k8s/ingress-tls/Chart.lock
+++ b/k8s-do/k8s/ingress-tls/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: cert-manager
+  repository: https://charts.jetstack.io
+  version: v1.6.1
+- name: ingress-nginx
+  repository: https://kubernetes.github.io/ingress-nginx
+  version: 4.0.16
+digest: sha256:be8feb236bdd4e362a685f5d2c56f075b68443440af020b7506f6a00a47996fe
+generated: "2022-01-20T18:14:49.306909+01:00"

--- a/k8s-do/k8s/ingress-tls/Chart.yaml
+++ b/k8s-do/k8s/ingress-tls/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ingress-tls
-description: ingress-tls installs and configures cert-manager, an ingress controller and a Let's Encrypt Issuer for automating TLS Certificates on AsyncAPI K8s services.
+description: "`ingress-tls` installs and configures `cert-manager`, an `Ingress Controller` and a Let's Encrypt Issuer for automating TLS Certificates on AsyncAPI K8s services."
 type: application
 version: 0.1.0
 appVersion: "v1.6.1" # version of cert-manager

--- a/k8s-do/k8s/ingress-tls/Chart.yaml
+++ b/k8s-do/k8s/ingress-tls/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: ingress-tls
+description: ingress-tls installs and configures cert-manager, an ingress controller and a Let's Encrypt Issuer for automating TLS Certificates on AsyncAPI K8s services.
+type: application
+version: 0.1.0
+appVersion: "v1.6.1" # version of cert-manager
+
+dependencies:
+  - name: cert-manager
+    version: 1.6.1
+    repository: "https://charts.jetstack.io"
+  - name: ingress-nginx
+    version: 4.0.16
+    repository: "https://kubernetes.github.io/ingress-nginx"

--- a/k8s-do/k8s/ingress-tls/README.md
+++ b/k8s-do/k8s/ingress-tls/README.md
@@ -2,7 +2,7 @@
 
 ![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.6.1](https://img.shields.io/badge/AppVersion-v1.6.1-informational?style=flat-square)
 
-ingress-tls installs and configures cert-manager, an ingress controller and a Let's Encrypt Issuer for automating TLS Certificates on AsyncAPI K8s services.
+`ingress-tls` installs and configures `cert-manager`, an `Ingress Controller` and a Let's Encrypt Issuer for automating TLS Certificates on AsyncAPI K8s services.
 
 ## Requirements
 
@@ -17,8 +17,8 @@ ingress-tls installs and configures cert-manager, an ingress controller and a Le
 |-----|------|---------|-------------|
 | cert-manager.installCRDs | bool | `true` |  |
 | certificates.issuer.acme.email | string | `"info@asyncapi.io"` |  |
-| certificates.issuer.acme.secret | string | `"letsencrypt-prod"` |  |
 | certificates.issuer.acme.server | string | `"https://acme-v02.api.letsencrypt.org/directory"` |  |
+| certificates.issuer.acme.tokenSecretDestination | string | `"letsencrypt-prod"` |  |
 | certificates.issuer.name | string | `"letsencrypt-prod"` |  |
 | certificates.issuer.namespace | string | `"default"` |  |
 

--- a/k8s-do/k8s/ingress-tls/README.md
+++ b/k8s-do/k8s/ingress-tls/README.md
@@ -1,0 +1,73 @@
+# ingress-tls
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.6.1](https://img.shields.io/badge/AppVersion-v1.6.1-informational?style=flat-square)
+
+ingress-tls installs and configures cert-manager, an ingress controller and a Let's Encrypt Issuer for automating TLS Certificates on AsyncAPI K8s services.
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.jetstack.io | cert-manager | 1.6.1 |
+| https://kubernetes.github.io/ingress-nginx | ingress-nginx | 4.0.16 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| cert-manager.installCRDs | bool | `true` |  |
+| certificates.issuer.acme.email | string | `"info@asyncapi.io"` |  |
+| certificates.issuer.acme.secret | string | `"letsencrypt-prod"` |  |
+| certificates.issuer.acme.server | string | `"https://acme-v02.api.letsencrypt.org/directory"` |  |
+| certificates.issuer.name | string | `"letsencrypt-prod"` |  |
+| certificates.issuer.namespace | string | `"default"` |  |
+
+## Installation
+
+First, install all dependencies:
+```bash
+helm dependency update
+```
+
+Then install the chart:
+```bash
+helm install ingress-tls . --namespace ingress-tls --create-namespace --atomic
+```
+
+This will install: 
+
+- [cert-manager](https://cert-manager.io/docs/), which takes care of issuing certificates, renewing them and managing the certificate resources. It can issue certificates from a variety of supported sources, including Let’s Encrypt, HashiCorp Vault, and Venafi as well as private PKI.
+- A cert-manager [Issuer](https://cert-manager.io/docs/concepts/issuer/), which represent Certificat Authorities that generate signed certificates. This is a needed piece for making [cert-manager](https://cert-manager.io/docs/) to work. By default, a Let's Encrypt Issuer is created.
+- [ingress-nginx](https://kubernetes.github.io/ingress-nginx/), which is an Nginx running as reverse-proxy and behaving as [K8s Ingress Controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/), listening to the creation of [K8s Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) resources, which are K8s resources that exposes services publicly, and allows configuring TLS.
+
+What this chart does not install:
+
+- [K8s Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for all services. This is something each service should take care of. An example:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: server-api
+  annotations:
+    cert-manager.io/issuer: letsencrypt-prod # here we use the name of the issuer we created through this chart.
+spec:
+  tls: 
+  - hosts:
+    - api.asyncapi.com
+    secretName: letsencrypt-prod-foo
+  ingressClassName: nginx
+  rules:
+  - host: api.asyncapi.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: server-api
+            port:
+              number: 80
+```
+
+With this, you will be able to configure your service to serve traffic over HTTPS with a Let's Encrypt certificate.

--- a/k8s-do/k8s/ingress-tls/templates/issuer.yaml
+++ b/k8s-do/k8s/ingress-tls/templates/issuer.yaml
@@ -1,0 +1,25 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Values.certificates.issuer.name }}
+  # Usually the namespace where the services that want to use certificates are located.
+  namespace: {{ .Values.certificates.issuer.namespace }}
+  annotations: 
+    helm.sh/hook: post-install
+    helm.sh/hook-weight: "100"
+spec:
+  acme:
+    # Let's Encrypt will use this to contact you about expiring
+    # certificates, and issues related to your account.
+    email: {{ .Values.certificates.issuer.acme.email }}
+    server: {{ .Values.certificates.issuer.acme.server }}
+    privateKeySecretRef:
+      # Secret resource that will be used to store the ACME account's private key, e.g. Let's Enctypt token. It's not a certificate.
+      # Make sure the name is unique and do not collision with any other secret name. 
+      # Note: This value should not be the same as Ingress secretName.
+      name: {{ .Values.certificates.issuer.acme.tokenSecretDestination }}
+    # Add a single challenge solver, HTTP01 using nginx
+    solvers:
+    - http01:
+        ingress:
+          class: nginx

--- a/k8s-do/k8s/ingress-tls/values.yaml
+++ b/k8s-do/k8s/ingress-tls/values.yaml
@@ -1,0 +1,11 @@
+cert-manager:
+  installCRDs: true
+
+certificates:
+  issuer:
+    name: letsencrypt-prod
+    namespace: default
+    acme:
+      email: info@asyncapi.io
+      server: https://acme-v02.api.letsencrypt.org/directory
+      tokenSecretDestination: letsencrypt-prod


### PR DESCRIPTION
**Description**

This helm chart installs:

- [cert-manager](https://cert-manager.io/docs/), which takes care of issuing certificates, renewing them and managing the certificate resources. It can issue certificates from a variety of supported sources, including Let’s Encrypt, HashiCorp Vault, and Venafi as well as private PKI.
- A cert-manager [Issuer](https://cert-manager.io/docs/concepts/issuer/), which represent Certificat Authorities that generate signed certificates. This is a needed piece for making [cert-manager](https://cert-manager.io/docs/) to work. By default, a Let's Encrypt Issuer is created.
- [ingress-nginx](https://kubernetes.github.io/ingress-nginx/), which is an Nginx running as reverse-proxy and behaving as [K8s Ingress Controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/), listening to the creation of [K8s Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) resources, which are K8s resources that exposes services publicly, and allows configuring TLS.

Means all services deployed to K8s can now use https with auto managed and renewed Let's Encrypt certificates. For example, https://github.com/asyncapi/server-api/pull/25.

cc @magicmatatjahu @derberg @fmvilas 